### PR TITLE
Refactor how EC integration gets current page’s locale

### DIFF
--- a/packages/starlight/index.ts
+++ b/packages/starlight/index.ts
@@ -39,7 +39,13 @@ export default function StarlightIntegration(opts: StarlightUserConfig): AstroIn
 				});
 				const integrations: AstroIntegration[] = [];
 				if (!config.integrations.find(({ name }) => name === 'astro-expressive-code')) {
-					integrations.push(...starlightExpressiveCode(userConfig, useTranslations));
+					integrations.push(
+						...starlightExpressiveCode({
+							starlightConfig: userConfig,
+							astroConfig: config,
+							useTranslations,
+						})
+					);
 				}
 				if (!config.integrations.find(({ name }) => name === '@astrojs/sitemap')) {
 					integrations.push(starlightSitemap(userConfig));

--- a/packages/starlight/integrations/shared/pathToLocale.ts
+++ b/packages/starlight/integrations/shared/pathToLocale.ts
@@ -1,0 +1,32 @@
+import type { StarlightConfig } from '../../types';
+
+function slugToLocale(
+	slug: string | undefined,
+	localesConfig: StarlightConfig['locales']
+): string | undefined {
+	const locales = Object.keys(localesConfig || {});
+	const baseSegment = slug?.split('/')[0];
+	return baseSegment && locales.includes(baseSegment) ? baseSegment : undefined;
+}
+
+/** Get current locale from the full file path. */
+export function pathToLocale(
+	path: string | undefined,
+	{
+		starlightConfig,
+		astroConfig,
+	}: {
+		starlightConfig: { locales: StarlightConfig['locales'] };
+		astroConfig: { root: URL; srcDir: URL };
+	}
+): string | undefined {
+	const srcDir = new URL(astroConfig.srcDir, astroConfig.root);
+	const docsDir = new URL('content/docs/', srcDir);
+	const slug = path
+		// Format path to unix style path.
+		?.replace(/\\/g, '/')
+		// Strip docs path leaving only content collection file ID.
+		// Example: /Users/houston/repo/src/content/docs/en/guide.md => en/guide.md
+		.replace(docsDir.pathname, '');
+	return slugToLocale(slug, starlightConfig.locales);
+}


### PR DESCRIPTION
#### Description

- This PR refactors how the Starlight Expressive Code integration gets the locale for the current page.
- We already wrote logic for this as part of https://github.com/withastro/starlight/pull/517 that accounts for things like user configuration of Astro’s `srcDir` option, so this PR pulls that out into a shared helper and reuses it.

<!--
Here’s what will happen next:
One or more of our maintainers will take a look and may ask you to make changes.
We try to be responsive, but don’t worry if this takes a day or two.
-->
