### PR TITLE
Rework EC docs and add changeset

### DIFF
--- a/.changeset/sweet-berries-begin.md
+++ b/.changeset/sweet-berries-begin.md
@@ -1,0 +1,44 @@
+---
+'@astrojs/starlight': minor
+---
+
+Adds Expressive Code as Starlight’s default code block renderer
+
+⚠️ **Potentially breaking change:**
+This addition changes how Markdown code blocks are rendered to use [Expressive Code](https://github.com/expressive-code/expressive-code/tree/main/packages/astro-expressive-code).
+If you were already customizing how code blocks are rendered, you may wish to disable Expressive Code to preserve previous behavior:
+
+```js
+starlight({
+  expressiveCode: false,
+})
+```
+
+If you had previously added Expressive Code manually to your Starlight project, you can now remove the manual set-up in `astro.config.mjs`:
+
+- Move your configuration to Starlight’s new `expressiveCode` option.
+- Remove the `astro-expressive-code` integration.
+
+For example:
+
+```diff
+import starlight from '@astrojs/starlight';
+import { defineConfig } from 'astro/config';
+- import expressiveCode from 'astro-expressive-code';
+
+export default defineConfig({
+  integrations: [
+-   expressiveCode({
+-     themes: ['rose-pine'],
+-   }),
+    starlight({
+      title: 'My docs',
++     expressiveCode: {
++       themes: ['rose-pine'],
++     },
+    }),
+  ],
+});
+```
+
+Note that the built-in Starlight version of Expressive Code sets some opinionated defaults that are different from the `astro-expressive-code` defaults. You may need to set some `styleOverrides` if you wish to keep styles exactly the same.

--- a/docs/src/content/docs/guides/authoring-content.md
+++ b/docs/src/content/docs/guides/authoring-content.md
@@ -202,15 +202,18 @@ var fun = function lang(l) {
 ```
 ````
 
-```md
-Long, single-line code blocks should not wrap. They should horizontally scroll if they are too long. This line should be long enough to demonstrate this.
-```
+### Expressive Code features
 
-### Text markers
+Starlight uses [Expressive Code](https://github.com/expressive-code/expressive-code/tree/main/packages/astro-expressive-code) to extend formatting possibilities for code blocks.
+Expressive Code’s text markers and window frames plugins are enabled by default.
+Code block rendering can be configured using Starlight’s [`expressiveCode` configuration option](/reference/configuration/#expressivecode).
 
-You can highlight specific lines or parts of your code blocks by using the text markers plugin of Expressive Code, which is enabled by default in Starlight. The following features are available:
+#### Text markers
 
-- [Marking entire lines & line ranges](https://github.com/expressive-code/expressive-code/blob/main/packages/%40expressive-code/plugin-text-markers/README.md#marking-entire-lines--line-ranges)
+You can highlight specific lines or parts of your code blocks using text markers.
+There are three styles of marker: a default neutral colored highlight, a green highlight indicating code that was inserted, and a red highlight indicating code that was deleted.
+
+- [Mark entire lines & line ranges](https://github.com/expressive-code/expressive-code/blob/main/packages/%40expressive-code/plugin-text-markers/README.md#marking-entire-lines--line-ranges):
 
   ```js {2-3}
   function demo() {
@@ -228,7 +231,7 @@ You can highlight specific lines or parts of your code blocks by using the text 
   ```
   ````
 
-- [Marking individual text inside lines](https://github.com/expressive-code/expressive-code/blob/main/packages/%40expressive-code/plugin-text-markers/README.md#marking-entire-lines--line-ranges)
+- [Mark selections of text](https://github.com/expressive-code/expressive-code/blob/main/packages/%40expressive-code/plugin-text-markers/README.md#marking-entire-lines--line-ranges):
 
   ```js "Individual terms" /Even.*supported/
   // Individual terms can be highlighted, too
@@ -246,14 +249,14 @@ You can highlight specific lines or parts of your code blocks by using the text 
   ```
   ````
 
-- [Selecting marker types `ins` or `del`](https://github.com/expressive-code/expressive-code/blob/main/packages/%40expressive-code/plugin-text-markers/README.md#selecting-marker-types-mark-ins-del)
+- [Mark text as inserted or deleted with `ins` or `del`](https://github.com/expressive-code/expressive-code/blob/main/packages/%40expressive-code/plugin-text-markers/README.md#selecting-marker-types-mark-ins-del):
 
   ```js "return true;" ins="inserted" del="deleted"
   function demo() {
     console.log('These are inserted and deleted marker types');
     // The return statement uses the default marker type
     return true;
-  };
+  }
   ```
 
   ````md
@@ -262,11 +265,11 @@ You can highlight specific lines or parts of your code blocks by using the text 
     console.log('These are inserted and deleted marker types');
     // The return statement uses the default marker type
     return true;
-  };
+  }
   ```
   ````
 
-- [Combining syntax highlighting with `diff`-like syntax](https://github.com/expressive-code/expressive-code/blob/main/packages/%40expressive-code/plugin-text-markers/README.md#combining-syntax-highlighting-with-diff-like-syntax)
+- [Combine syntax highlighting with `diff`-like syntax](https://github.com/expressive-code/expressive-code/blob/main/packages/%40expressive-code/plugin-text-markers/README.md#combining-syntax-highlighting-with-diff-like-syntax):
 
   ```diff lang="js"
     function thisIsJavaScript() {
@@ -288,39 +291,41 @@ You can highlight specific lines or parts of your code blocks by using the text 
   ```
   ````
 
-### Window frames
+#### Frames and titles
 
-By default, every code block that has a language identifier is rendered inside a window frame. This is done by the frames plugin of Expressive Code, which is enabled by default in Starlight. Depending on the code's language identifier, the frame can look like a code editor (similar to VS Code), or like a terminal window.
+Code blocks can be rendered inside a window-like frame.
+A frame that looks like a terminal window will be used for shell scripting languages (e.g. `bash` or `sh`).
+Other languages display inside a code editor-style frame if they include a title.
 
-Frames can have optional titles, which are either taken from a `title="..."` attribute following the code block's opening backticks and language identifier, or from a file name comment in the first lines of the code.
+A code block’s optional title can be set either with a `title="..."` attribute following the code block's opening backticks and language identifier, or with a file name comment in the first lines of the code.
 
-- [Code editor with optional file name tab title](https://github.com/expressive-code/expressive-code/blob/main/packages/%40expressive-code/plugin-frames/README.md#code-editor-window-frames)
+- [Add a file name tab with a comment](https://github.com/expressive-code/expressive-code/blob/main/packages/%40expressive-code/plugin-frames/README.md#code-editor-window-frames)
 
   ```js
   // my-test-file.js
-  console.log('Hello World!')
+  console.log('Hello World!');
   ```
 
   ````md
   ```js
   // my-test-file.js
-  console.log('Hello World!')
+  console.log('Hello World!');
   ```
   ````
 
-- [Terminal with optional window title](https://github.com/expressive-code/expressive-code/blob/main/packages/%40expressive-code/plugin-frames/README.md#terminal-window-frames)
+- [Add a title to a Terminal window](https://github.com/expressive-code/expressive-code/blob/main/packages/%40expressive-code/plugin-frames/README.md#terminal-window-frames)
 
-  ```bash title="Installing dependencies"
+  ```bash title="Installing dependencies…"
   npm install
   ```
 
   ````md
-  ```bash title="Installing dependencies"
+  ```bash title="Installing dependencies…"
   npm install
   ```
   ````
 
-- [Disabling window frames for individual blocks](https://github.com/expressive-code/expressive-code/blob/main/packages/%40expressive-code/plugin-frames/README.md#overriding-frame-types)
+- [Disable window frames with `frame="none"`](https://github.com/expressive-code/expressive-code/blob/main/packages/%40expressive-code/plugin-frames/README.md#overriding-frame-types)
 
   ```bash frame="none"
   echo "This is not rendered as a terminal despite using the bash language"

--- a/docs/src/content/docs/reference/configuration.mdx
+++ b/docs/src/content/docs/reference/configuration.mdx
@@ -65,33 +65,6 @@ type LogoConfig = { alt?: string; replacesTitle?: boolean } & (
 
 Configure the table of contents shown on the right of each page. By default, `<h2>` and `<h3>` headings will be included in this table of contents.
 
-### `expressiveCode`
-
-**type:** `StarlightExpressiveCodeOptions | boolean`
-
-Starlight uses [Expressive Code](https://github.com/expressive-code/expressive-code/tree/main/packages/astro-expressive-code) to render code blocks on your site. The integration is enabled by default and can be disabled by passing `false` to this option.
-
-You can customize your code blocks by passing an object with any of the following properties:
-
-- `themes` — an array of themes that should be used to render code blocks. The following item types are supported in this array:
-  - any theme name bundled with Shiki (e.g. `dracula`)
-  - any theme object compatible with VS Code or Shiki (e.g. imported from an NPM theme package)
-  - any ExpressiveCodeTheme instance (e.g. using `ExpressiveCodeTheme.fromJSONString(...)` to load a custom JSON/JSONC theme file yourself)
-
-  Defaults to the dark and light variants of the "Night Owl" theme by Sarah Drasner, which are also exported from `@astrojs/starlight/expressive-code` as `getStarlightDefaultThemes`.
-
-  **Note**: If you pass at least one dark and one light theme to this option, Starlight will automatically ensure that the displayed theme matches the current dark mode switch state. See the `useStarlightDarkModeSwitch` option to configure this behavior. If you turn it off, you will need to add your own CSS code to the site to allow manual switching between themes.
-
-- `useStarlightDarkModeSwitch` — determines if CSS code should be added that automatically displays dark or light code blocks depending on Starlight's dark mode switch state.
-
-  Defaults to `true` if the `themes` option is not set or contains at least one dark and one light theme, and `false` otherwise.
-
-- `useStarlightUiThemeColors` — determines if Starlight's CSS variables should be used for the colors of UI elements (backgrounds, buttons, shadows etc.) instead of the colors provided by themes.
-
-  Defaults to `true` if the `themes` option is not set (= you are using the default themes), and `false` otherwise.
-
-- See the [Expressive Code documentation](https://github.com/expressive-code/expressive-code/blob/main/packages/astro-expressive-code/README.md#configuration) to learn about all the other options.
-
 ### `editLink`
 
 **type:** `{ baseUrl: string }`
@@ -372,6 +345,68 @@ starlight({
 	customCss: ['./src/custom-styles.css', '@fontsource/roboto'],
 });
 ```
+
+### `expressiveCode`
+
+**type:** `StarlightExpressiveCodeOptions | boolean`  
+**default:** `true`
+
+Starlight uses [Expressive Code](https://github.com/expressive-code/expressive-code/tree/main/packages/astro-expressive-code) to render code blocks and add support for highlighting parts of code examples, adding filenames to code blocks, and more.
+See the [“Code blocks” guide](/guides/authoring-content/#code-blocks) to learn how to use Expressive Code syntax in your Markdown and MDX content.
+
+You can use any of the standard [Expressive Code configuration options](https://github.com/expressive-code/expressive-code/blob/main/packages/astro-expressive-code/README.md#configuration) by setting them in Starlight’s `expressiveCode` option.
+For example, to give your code blocks rounded corners, set the `styleOverrides.borderRadius` option:
+
+```js ins={2-4}
+starlight({
+	expressiveCode: {
+		styleOverrides: { borderRadius: '0.5rem' },
+	},
+});
+```
+
+If you want to disable Expressive Code, set `expressiveCode: false` in your Starlight config:
+
+```js ins={2}
+starlight({
+	expressiveCode: false,
+});
+```
+
+In addition to the standard Expressive Code options, you can customize your code blocks with the following Starlight-specific properties:
+
+#### `themes`
+
+**type:** `Array<string | ThemeObject | ExpressiveCodeTheme>`  
+**default:** `['starlight-dark', 'starlight-light']`
+
+Set the themes used to style code blocks.
+See the [Expressive Code `themes` documentation](https://github.com/expressive-code/expressive-code/blob/main/packages/astro-expressive-code/README.md#themes) for details of the supported theme formats.
+
+Starlight uses the dark and light variants of Sarah Drasner’s [Night Owl theme](https://github.com/sdras/night-owl-vscode-theme) by default.
+
+If you provide at least one dark and one light theme, Starlight will automatically keep the active code block theme in sync with the current site theme.
+Configure this behavior with the [`useStarlightDarkModeSwitch`](#usestarlightdarkmodeswitch) option.
+
+#### `useStarlightDarkModeSwitch`
+
+**type:** `boolean`  
+**default:** `true`
+
+When `true`, code blocks automatically switch between light and dark themes when the site theme changes.
+When `false`, you must manually add CSS to handle switching between multiple themes.
+
+:::note
+When setting `themes`, you must provide at least one dark and one light theme for the Starlight dark mode switch to work.
+:::
+
+#### `useStarlightUiThemeColors`
+
+**type:** `boolean`  
+**default:** `true`
+
+When `true`, Starlight's CSS variables are used for the colors of code block UI elements (backgrounds, buttons, shadows etc.), matching the [site color theme](/guides/css-and-tailwind/#theming).
+When `false`, the colors provided by the active syntax highlighting theme are used for these elements.
 
 ### `head`
 


### PR DESCRIPTION
#### Description

- This PR reworks the configuration reference and Markdown usage documentation for Expressive Code.
- Note that the config reference makes some changes that are not yet reflected in code, but have been discussed in https://github.com/withastro/starlight/pull/742. Hopefully seeing the docs also shows how these tweaks help make the configuration options easier to understand.
- I have also added a changeset as part of this PR, which tries to outline the changes people may need to make when upgrading.

<!--
Here’s what will happen next:
One or more of our maintainers will take a look and may ask you to make changes.
We try to be responsive, but don’t worry if this takes a day or two.
-->
